### PR TITLE
feat: use official Alpine with source-built glibc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,6 @@ README.en.md
 LICENSE
 docs
 snell-server-help.txt
-tests
+tests/*
+!tests/runtime_contract.sh
+!tests/image_contract.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,17 @@ on:
   push:
     branches:
       - main
+      - alpine
   pull_request:
+  workflow_call:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -26,6 +32,7 @@ jobs:
           sh -n tests/latest_version_contract.sh
           sh -n tests/runtime_contract.sh
           sh -n tests/docker_smoke.sh
+          sh -n tests/image_contract.sh
 
       - name: Run runtime contract tests
         run: sh tests/runtime_contract.sh
@@ -35,3 +42,11 @@ jobs:
 
       - name: Run Docker smoke tests
         run: sh tests/docker_smoke.sh snell:test
+
+      - name: Run Alpine and glibc contracts
+        run: |
+          docker build --target test -t snell:checks .
+          docker run --rm snell:checks
+
+      - name: Report runtime image size
+        run: docker image inspect snell:test --format 'Runtime image size (Docker reported) = {{.Size}} bytes'

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -10,27 +10,15 @@ env:
   VCS_URL: https://github.com/angribot/snell-server-docker
 
 jobs:
+  verify:
+    uses: ./.github/workflows/ci.yaml
+
   main:
+    needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-
-      - name: Check shell syntax
-        run: |
-          sh -n entrypoint.sh
-          sh -n runtime-config.sh
-          sh -n .github/scripts/snell-version-lifecycle.sh
-          sh -n tests/release_version_contract.sh
-          sh -n tests/latest_version_contract.sh
-          sh -n tests/runtime_contract.sh
-          sh -n tests/docker_smoke.sh
-
-      - name: Run host contract tests
-        run: |
-          sh tests/release_version_contract.sh
-          sh tests/latest_version_contract.sh
-          sh tests/runtime_contract.sh
 
       - name: Set build metadata
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,85 @@
 # syntax=docker/dockerfile:1
 ARG SNELL_VERSION=v6.0.0rc2
 
-FROM debian:stable-slim AS builder
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS builder
 
-ARG TARGETPLATFORM=linux/amd64
-ARG SNELL_VERSION
+ARG TARGETARCH
+# Update the version and source checksum together.
+ARG GLIBC_VERSION=2.44
+ARG GLIBC_SHA256=37f600f2bef3c5e8300147059568b2a2e40a7ad6ccc65ce942556d49429cc667
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates wget unzip && \
+RUN case "${TARGETARCH}" in \
+      amd64) toolchain=x86-64; cross_arch=amd64 ;; \
+      arm64) toolchain=aarch64; cross_arch=arm64 ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates wget unzip xz-utils make bison gawk python3 gcc \
+      "gcc-${toolchain}-linux-gnu" "libc6-dev-${cross_arch}-cross" && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/glibc-build
+
+RUN wget -q -O glibc.tar.xz "https://ftp.gnu.org/gnu/glibc/glibc-${GLIBC_VERSION}.tar.xz" && \
+    echo "${GLIBC_SHA256}  glibc.tar.xz" | sha256sum -c - && \
+    tar -xf glibc.tar.xz && \
+    mkdir build && cd build && \
+    case "${TARGETARCH}" in \
+      amd64) target=x86_64-linux-gnu ;; \
+      arm64) target=aarch64-linux-gnu ;; \
+    esac && \
+    CC="${target}-gcc" ../glibc-${GLIBC_VERSION}/configure \
+      --build="$(gcc -dumpmachine)" --host="${target}" \
+      --prefix=/opt/glibc --libdir=/opt/glibc/lib \
+      --with-headers="/usr/${target}/include" \
+      --disable-werror --disable-nscd --enable-stack-protector=strong \
+      CFLAGS="-O2 -g0" && \
+    make -j"$(nproc)" && \
+    make install DESTDIR=/tmp/glibc-install
+
+# Keep the loader, DNS support and Snell's runtime libraries, not development files.
+RUN case "${TARGETARCH}" in \
+      amd64) target=x86_64-linux-gnu ;; \
+      arm64) target=aarch64-linux-gnu ;; \
+    esac && \
+    mkdir -p /runtime/opt/glibc/lib && \
+    cp -a /tmp/glibc-install/opt/glibc/lib/ld-linux*.so.* /runtime/opt/glibc/lib/ && \
+    for library in libc.so.6 libm.so.6 libdl.so.2 \
+      libpthread.so.0 librt.so.1 libresolv.so.2; do \
+      cp -a "/tmp/glibc-install/opt/glibc/lib/${library}" /runtime/opt/glibc/lib/ || exit 1; \
+    done && \
+    for library in libstdc++.so.6 libgcc_s.so.1; do \
+      cp -L "$(${target}-gcc -print-file-name=${library})" \
+        "/runtime/opt/glibc/lib/${library}" || exit 1; \
+    done && \
+    ${target}-strip --strip-unneeded /runtime/opt/glibc/lib/*.so* && \
+    mkdir -p /runtime/usr/share/licenses/glibc && \
+    cp glibc-${GLIBC_VERSION}/COPYING.LIB glibc-${GLIBC_VERSION}/LICENSES \
+      /runtime/usr/share/licenses/glibc/ && \
+    mkdir -p /runtime/usr/share/licenses/gcc-runtime && \
+    cp /usr/share/doc/gcc-$(${target}-gcc -dumpversion)-base/copyright \
+      /usr/share/common-licenses/GPL-3 /runtime/usr/share/licenses/gcc-runtime/ && \
+    case "${TARGETARCH}" in \
+      amd64) mkdir -p /runtime/lib64; \
+        ln -s /opt/glibc/lib/ld-linux-x86-64.so.2 /runtime/lib64/ld-linux-x86-64.so.2 ;; \
+      arm64) mkdir -p /runtime/lib; \
+        ln -s /opt/glibc/lib/ld-linux-aarch64.so.1 /runtime/lib/ld-linux-aarch64.so.1 ;; \
+    esac
 
 WORKDIR /tmp/snell-build
 
-RUN case "${TARGETPLATFORM}" in \
-      "linux/amd64") snell_arch="amd64" ;; \
-      "linux/arm64") snell_arch="aarch64" ;; \
-      *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+ARG SNELL_VERSION
+
+RUN case "${TARGETARCH}" in \
+      amd64) snell_arch=amd64 ;; \
+      arm64) snell_arch=aarch64 ;; \
     esac && \
     wget -q -O snell.zip "https://dl.nssurge.com/snell/snell-server-${SNELL_VERSION}-linux-${snell_arch}.zip" && \
     unzip -q snell.zip && \
     test -x /tmp/snell-build/snell-server
 
-FROM debian:stable-slim
+FROM alpine:3.23 AS runtime
 
 ARG SNELL_VERSION
 ARG BUILD_DATE=unknown
@@ -35,6 +93,7 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
 
 WORKDIR /snell
 
+COPY --from=builder /runtime/ /
 COPY --from=builder /tmp/snell-build/snell-server /snell/snell-server
 COPY entrypoint.sh runtime-config.sh /snell/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,3 +100,13 @@ COPY entrypoint.sh runtime-config.sh /snell/
 RUN chmod +x /snell/snell-server /snell/entrypoint.sh
 
 ENTRYPOINT ["/snell/entrypoint.sh"]
+
+FROM runtime AS test
+
+RUN apk add --no-cache dnsmasq
+COPY --from=builder /tmp/glibc-install/opt/glibc/bin/getent /usr/local/bin/glibc-getent
+COPY tests/runtime_contract.sh tests/image_contract.sh /snell/tests/
+ENTRYPOINT ["/bin/sh", "/snell/tests/image_contract.sh"]
+
+# The default build remains the production image, without test tools or fixtures.
+FROM runtime AS final

--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,18 @@ To let that automated tag still trigger the existing Docker publish workflow, co
 - The default `GITHUB_TOKEN` is not enough because push / tag events created by it do not trigger downstream workflows
 - The token needs write access to this repository
 
+## Image Build
+
+The runtime uses official `alpine:3.23`, not a third-party alpine-glibc image or `gcompat`. Alpine's musl remains intact for its system tools.
+
+An official Debian builder compiles [GNU glibc 2.44](https://ftp.gnu.org/gnu/glibc/glibc-2.44.tar.xz) from source, verified by the SHA-256 in `Dockerfile`, for `linux/amd64` and `linux/arm64`. The target compiler runs on the build host architecture. glibc is installed under `/opt/glibc`; only the loader, selected stripped shared libraries, and matching GNU C++/GCC runtime libraries from Debian enter the final image. Compiler tools, headers, static libraries, locale archives, and build sources are excluded. Runtime library license notices are retained under `/usr/share/licenses`.
+
+```shell
+docker buildx build --platform linux/amd64,linux/arm64 -t snell:alpine .
+```
+
+`GLIBC_VERSION` and `GLIBC_SHA256` must be updated together. glibc and the copied GNU runtime libraries are not managed by Alpine's `apk`: security updates require rebuilding the image, using `--pull --no-cache` to refresh the builder packages. Changing only `SNELL_VERSION` can reuse the glibc build cache. This is a minimal Snell runtime, not a general-purpose glibc environment; full locale and character conversion modules are intentionally omitted.
+
 ## Networking Notes
 
 - `host` mode is the primary and recommended deployment path

--- a/README.en.md
+++ b/README.en.md
@@ -69,13 +69,13 @@ These legacy names will be removed when Snell Server v6 stable is released.
 - A bare `rc` sorts as `rc1`; versions with the same `X.Y.Z` sort as beta, release candidate, then stable
 - Tag-triggered builds require the Git tag name to match the bundled `SNELL_VERSION`
 - The build fails if the tag and bundled version differ
-- Until Snell Server v6 stable is released, `latest` points to the newest validated beta or release candidate image
+- `latest` is updated only when the tagged commit is also the default branch HEAD; before Snell Server v6 stable, it can point to a validated beta or release candidate
 
 ## Auto Update
 
 The repository includes an optional GitHub Actions workflow: `.github/workflows/auto_bump.yaml`.
 
-- It runs every day at `00:30` China Standard Time (`30 16 * * *` in GitHub UTC cron)
+- It runs every day at `23:00` China Standard Time (`0 15 * * *` in GitHub UTC cron)
 - It fetches the Snell release notes page and resolves the newest downloadable version
 - It only updates `SNELL_VERSION` when that resolved version is strictly newer than the version currently bundled in `Dockerfile`
 - When an update is found, it creates a commit named `chore: bump snell to <version>` and a Git tag with the same version name
@@ -92,10 +92,14 @@ The runtime uses official `alpine:3.23`, not a third-party alpine-glibc image or
 An official Debian builder compiles [GNU glibc 2.44](https://ftp.gnu.org/gnu/glibc/glibc-2.44.tar.xz) from source, verified by the SHA-256 in `Dockerfile`, for `linux/amd64` and `linux/arm64`. The target compiler runs on the build host architecture. glibc is installed under `/opt/glibc`; only the loader, selected stripped shared libraries, and matching GNU C++/GCC runtime libraries from Debian enter the final image. Compiler tools, headers, static libraries, locale archives, and build sources are excluded. Runtime library license notices are retained under `/usr/share/licenses`.
 
 ```shell
-docker buildx build --platform linux/amd64,linux/arm64 -t snell:alpine .
+docker buildx build --platform linux/amd64 --load -t snell:alpine .
 ```
 
 `GLIBC_VERSION` and `GLIBC_SHA256` must be updated together. glibc and the copied GNU runtime libraries are not managed by Alpine's `apk`: security updates require rebuilding the image, using `--pull --no-cache` to refresh the builder packages. Changing only `SNELL_VERSION` can reuse the glibc build cache. This is a minimal Snell runtime, not a general-purpose glibc environment; full locale and character conversion modules are intentionally omitted.
+
+## Tests
+
+Tests cover version rules, runtime configuration, and amd64/arm64 image integration. See the [testing guide](docs/testing.md) for commands and CI details.
 
 ## Networking Notes
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ services:
 - 不能使用默认 `GITHUB_TOKEN`，因为它触发的 push / tag 事件不会继续触发其他 workflow
 - 这个 token 需要具备对当前仓库的写权限
 
+## 镜像构建
+
+运行基底使用官方 `alpine:3.23`，不使用第三方 alpine-glibc 镜像或 `gcompat`。Alpine 的系统工具继续使用原有 musl。
+
+官方 Debian 构建阶段从源码编译 [GNU glibc 2.44](https://ftp.gnu.org/gnu/glibc/glibc-2.44.tar.xz)，通过 `Dockerfile` 中的 SHA-256 校验，支持 `linux/amd64` 和 `linux/arm64`。目标工具链在构建宿主架构上运行。glibc 安装在 `/opt/glibc`；最终镜像只保留动态加载器、选定且已剥离符号的共享库，以及 Debian 提供的配套 GNU C++/GCC 运行库。不包含编译工具、头文件、静态库、locale 归档或构建源码。运行库许可证保留在 `/usr/share/licenses`。
+
+```shell
+docker buildx build --platform linux/amd64,linux/arm64 -t snell:alpine .
+```
+
+`GLIBC_VERSION` 与 `GLIBC_SHA256` 必须一起更新。glibc 和复制的 GNU 运行库不由 Alpine 的 `apk` 管理：安全更新需要重新构建镜像，可用 `--pull --no-cache` 刷新构建阶段的软件包。仅修改 `SNELL_VERSION` 可以复用 glibc 编译缓存。这是精简的 Snell 运行环境，不是通用 glibc 环境，有意省略完整 locale 和字符集转换模块。
+
 ## 网络说明
 
 - `host` 模式是官方推荐路径

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ services:
 - 裸 `rc` 按 `rc1` 排序；同一 `X.Y.Z` 下，版本顺序为测试版、候选版、正式版
 - Git tag 触发的镜像构建要求 tag 名与内置 `SNELL_VERSION` 完全一致
 - 如果两者不一致，构建会失败
-- 在 Snell Server v6 正式版发布前，`latest` 指向最近一次通过校验的测试版或候选版镜像
+- 仅当 tag 对应提交同时是默认分支 HEAD 时才更新 `latest`；在 Snell Server v6 正式版发布前，它可以指向已验证的测试版或候选版
 
 ## 自动更新
 
 仓库内置了一个可选的 GitHub Actions workflow：`.github/workflows/auto_bump.yaml`。
 
-- 每天北京时间 `00:30` 运行一次（GitHub cron 为 `30 16 * * *`，即 UTC `16:30`）
+- 每天北京时间 `23:00` 运行一次（GitHub cron 为 `0 15 * * *`，即 UTC `15:00`）
 - 抓取 Snell release notes 页面，解析出最新可下载版本
 - 只有在最新版本严格高于当前 `Dockerfile` 内置版本时，才会更新 `SNELL_VERSION`
 - 更新后会自动创建提交 `chore: bump snell to <version>`，并打上同名 Git tag
@@ -92,10 +92,14 @@ services:
 官方 Debian 构建阶段从源码编译 [GNU glibc 2.44](https://ftp.gnu.org/gnu/glibc/glibc-2.44.tar.xz)，通过 `Dockerfile` 中的 SHA-256 校验，支持 `linux/amd64` 和 `linux/arm64`。目标工具链在构建宿主架构上运行。glibc 安装在 `/opt/glibc`；最终镜像只保留动态加载器、选定且已剥离符号的共享库，以及 Debian 提供的配套 GNU C++/GCC 运行库。不包含编译工具、头文件、静态库、locale 归档或构建源码。运行库许可证保留在 `/usr/share/licenses`。
 
 ```shell
-docker buildx build --platform linux/amd64,linux/arm64 -t snell:alpine .
+docker buildx build --platform linux/amd64 --load -t snell:alpine .
 ```
 
 `GLIBC_VERSION` 与 `GLIBC_SHA256` 必须一起更新。glibc 和复制的 GNU 运行库不由 Alpine 的 `apk` 管理：安全更新需要重新构建镜像，可用 `--pull --no-cache` 刷新构建阶段的软件包。仅修改 `SNELL_VERSION` 可以复用 glibc 编译缓存。这是精简的 Snell 运行环境，不是通用 glibc 环境，有意省略完整 locale 和字符集转换模块。
+
+## 测试
+
+覆盖版本规则、运行配置及 amd64/arm64 镜像运行检查。命令与 CI 说明见[测试指南](docs/testing.md)。
 
 ## 网络说明
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,46 @@
+# Testing
+
+Run commands from the repository root. Tests cover version lifecycle, runtime configuration, and normal image-integration boundaries—not complete encrypted proxy requests or rare failure injection. Keep generated logs and temporary files outside Git.
+
+## Host contracts
+
+Requires a POSIX shell:
+
+```sh
+sh tests/release_version_contract.sh
+sh tests/latest_version_contract.sh
+sh tests/runtime_contract.sh
+```
+
+## Linux Docker
+
+Use an IPv6-enabled Linux host and build for its native architecture:
+
+```sh
+docker build -t snell:test .
+sh tests/docker_smoke.sh snell:test
+docker build --target test -t snell:checks .
+docker run --rm snell:checks
+```
+
+- **Smoke:** runs the production image with init and host networking; waits for IPv4/IPv6 TCP connectivity, checks runtime summaries and that logs do not expose the test PSK, and accepts only exit codes 0 or 143 after stopping. Set `PORT_VALUE` to override port `28345`.
+- **Image contract:** reuses the runtime configuration tests under Alpine and checks glibc hosts/DNS resolution using the build's `getent` and a local DNS fixture, without public DNS. Tools and fixtures are confined to the `test` target; the default production image excludes them.
+
+## Apple container
+
+With the `container` system running on macOS:
+
+```sh
+container build --platform linux/arm64 -t snell:test .
+CONTAINER_ENGINE=container sh tests/docker_smoke.sh snell:test
+container build --platform linux/arm64 --target test -t snell:checks .
+container run --rm snell:checks
+```
+
+For amd64, replace the build platform with `linux/amd64` and export `CONTAINER_DEFAULT_PLATFORM=linux/amd64` for the run commands. These checks use the container VM's network, not Docker's Linux host network.
+
+## CI
+
+Pushes to `main`/`alpine` and pull requests run checks on native `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` runners. Tag publishing calls the same verification workflow and waits for both architectures before building and pushing.
+
+CI reports Docker's image-size value without a fixed threshold; its interpretation can vary with the Docker storage backend.

--- a/tests/docker_smoke.sh
+++ b/tests/docker_smoke.sh
@@ -3,40 +3,69 @@ set -eu
 
 IMAGE="${1:-snell:test}"
 PORT_VALUE="${PORT_VALUE:-28345}"
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
+CONTAINER_NAME="snell-smoke-$$"
+PSK_VALUE=snell-smoke-test-key
 LOG_FILE="$(mktemp)"
-CONTAINER_ID=""
+RUN_PID=""
 
 cleanup() {
-  rm -f "$LOG_FILE"
-  if [ -n "$CONTAINER_ID" ]; then
-    docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true
+  result=$?
+  if [ "$result" -ne 0 ]; then
+    cat "$LOG_FILE" >&2
   fi
+  "$CONTAINER_ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  if [ -n "$RUN_PID" ]; then
+    wait "$RUN_PID" 2>/dev/null || true
+  fi
+  rm -f "$LOG_FILE"
 }
 trap cleanup EXIT
 
-CONTAINER_ID="$(docker run -d --init --network host -e PORT="$PORT_VALUE" -e PSK=abcdefghijkl -e DNS_IP_PREFERENCE=ipv4-only -e LOG_LEVEL=verbose "$IMAGE")"
-sleep 2
-docker logs "$CONTAINER_ID" >"$LOG_FILE" 2>&1
+case "$CONTAINER_ENGINE" in
+  docker) set -- --network host ;;
+  container) set -- ;;
+  *) echo "CONTAINER_ENGINE must be docker or container" >&2; exit 1 ;;
+esac
 
-if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_ID")" != "true" ]; then
-  echo "container exited before the smoke test completed" >&2
-  cat "$LOG_FILE" >&2
+# Keep the attached process so both engines expose the actual exit status.
+"$CONTAINER_ENGINE" run --init --name "$CONTAINER_NAME" "$@" \
+  -e PORT="$PORT_VALUE" -e PSK="$PSK_VALUE" \
+  -e DNS_IP_PREFERENCE=ipv4-only -e LOG_LEVEL=verbose "$IMAGE" >"$LOG_FILE" 2>&1 &
+RUN_PID=$!
+
+attempt=0
+until "$CONTAINER_ENGINE" exec "$CONTAINER_NAME" nc -z -w 1 127.0.0.1 "$PORT_VALUE" >/dev/null 2>&1 && \
+  "$CONTAINER_ENGINE" exec "$CONTAINER_NAME" nc -z -w 1 ::1 "$PORT_VALUE" >/dev/null 2>&1; do
+  if ! kill -0 "$RUN_PID" 2>/dev/null; then
+    echo "container exited before Snell was ready" >&2
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 30 ]; then
+    echo "Snell did not listen on both IPv4 and IPv6 before the timeout" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+grep -Fxq "PORT:${PORT_VALUE}" "$LOG_FILE"
+grep -Fxq 'LOG_LEVEL:verbose' "$LOG_FILE"
+grep -Fxq 'DNS_IP_PREFERENCE:ipv4-only' "$LOG_FILE"
+
+"$CONTAINER_ENGINE" stop -t 2 "$CONTAINER_NAME" >/dev/null
+exit_code=0
+wait "$RUN_PID" || exit_code=$?
+RUN_PID=""
+
+if grep -Fq "$PSK_VALUE" "$LOG_FILE" || grep -q '^PSK:' "$LOG_FILE"; then
+  echo "container logs must not expose PSK" >&2
   exit 1
 fi
 
-grep -q "PORT:${PORT_VALUE}" "$LOG_FILE"
-grep -q 'LOG_LEVEL:verbose' "$LOG_FILE"
-grep -q 'DNS_IP_PREFERENCE:ipv4-only' "$LOG_FILE"
+case "$exit_code" in
+  0|143) ;;
+  *) echo "unexpected container exit code: ${exit_code}" >&2; exit 1 ;;
+esac
 
-if grep -q '^PSK:' "$LOG_FILE"; then
-  echo "runtime summary must not expose PSK" >&2
-  exit 1
-fi
-
-docker stop -t 2 "$CONTAINER_ID" >/dev/null
-exit_code="$(docker inspect -f '{{.State.ExitCode}}' "$CONTAINER_ID")"
-
-if [ "$exit_code" -eq 137 ]; then
-  echo "container was force-killed instead of exiting gracefully" >&2
-  exit 1
-fi
+printf 'Snell smoke passed: %s (exit %s)\n' "$IMAGE" "$exit_code"

--- a/tests/image_contract.sh
+++ b/tests/image_contract.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+DNS_PID=""
+cleanup() {
+  if [ -n "$DNS_PID" ]; then
+    kill "$DNS_PID" 2>/dev/null || true
+    wait "$DNS_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Run the existing configuration contract with Alpine's shell and tools.
+test -f /etc/alpine-release
+sh "$(dirname "$0")/runtime_contract.sh"
+
+printf '\n192.0.2.124 snell-host.test\n' >> /etc/hosts
+/usr/local/bin/glibc-getent ahostsv4 snell-host.test | grep -q '^192\.0\.2\.124 '
+
+# Keep resolver checks independent of public DNS and the host's proxy settings.
+printf 'nameserver 127.0.0.1\noptions timeout:1 attempts:1\n' > /etc/resolv.conf
+dnsmasq --keep-in-foreground --conf-file=/dev/null --no-resolv --no-hosts \
+  --bind-interfaces --listen-address=127.0.0.1 --user=root \
+  --address=/snell.test/192.0.2.123 &
+DNS_PID=$!
+
+attempt=0
+until /usr/local/bin/glibc-getent ahostsv4 snell.test | grep -q '^192\.0\.2\.123 '; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 10 ]; then
+    echo "glibc could not resolve the local DNS fixture" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+printf 'Alpine runtime configuration and glibc resolution passed\n'


### PR DESCRIPTION
## Summary

- Replace the Debian runtime with official Alpine and source-built glibc, without third-party alpine-glibc images.
- Reduce the arm64 compressed image from 31.5 MB to 7.9 MB while preserving runtime configuration.
- Add focused integration tests, gate publishing on native amd64/arm64 CI, and update documentation.

## Verification

- [x] Host contracts, shell checks, and workflow lint
- [x] Local amd64/arm64 builds, startup, IPv4/IPv6 listening, glibc resolution, and shutdown
- [x] Linux Docker arm64 host-network smoke test
- [x] Standards and Spec reviews: no findings
- [ ] Native GitHub Actions checks — pending PR
- [ ] Full encrypted proxy traffic — not tested

Merging does not publish `latest`; publishing remains Git-tag-triggered.